### PR TITLE
Fix Helm release to use GHCR instead of GH releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
+        with:
+          skip_upload: true
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Should (hopefully) fix the error when running the Helm release workflow.

> [!Note]
> It would be better to delete the [release](https://github.com/Kooper/IngreSsh/releases/tag/ingressh-1.0.0) *and* the [tag](https://github.com/Kooper/IngreSsh/tags) first.