### PR TITLE
Use proper Renovate versionning template

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,7 +34,7 @@
       "matchStringsStrategy": "combination",
       "depNameTemplate": "ghcr.io/kooper/{{{depName}}}",
       "datasourceTemplate": "docker",
-      "versioningTemplate": "composer"
+      "versioningTemplate": "semver-coerced"
     }
   ]
 }


### PR DESCRIPTION
Fixing the way Renovate is going to parse docker image version.
To make it running, have you enabled the app on the repo? 😊
https://github.com/apps/renovate